### PR TITLE
[DBRE-1491] Update secretsEngineMap to used LInkedHashMap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven-publish'
 
 group 'com.bettercloud'
 archivesBaseName = 'vault-java-driver'
-version '5.3.0'
+version '5.4.0'
 ext.isReleaseVersion = true //!version.endsWith('SNAPSHOT')
 
 // This project is actually limited to Java 8 compatibility.  See below.

--- a/src/main/java/com/bettercloud/vault/VaultConfig.java
+++ b/src/main/java/com/bettercloud/vault/VaultConfig.java
@@ -1,8 +1,8 @@
 package com.bettercloud.vault;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * <p>A container for the configuration settings needed to initialize a <code>Vault</code> driver instance.</p>
@@ -30,7 +30,7 @@ public class VaultConfig implements Serializable {
     private static final String VAULT_OPEN_TIMEOUT = "VAULT_OPEN_TIMEOUT";
     private static final String VAULT_READ_TIMEOUT = "VAULT_READ_TIMEOUT";
 
-    private Map<String, String> secretsEnginePathMap = new ConcurrentHashMap<>();
+    private Map<String, String> secretsEnginePathMap = new LinkedHashMap<>();
     private String address;
     private String token;
     private SslConfig sslConfig;
@@ -136,6 +136,8 @@ public class VaultConfig implements Serializable {
 
     /**
      * <p>Sets the secrets Engine paths used by Vault.</p>
+     * NOTE: This uses a LinkedHashMap for ordering entries in the map, but could cause performance issues in the future.
+     * In the case of performance issues, consider replacing with a concurrentHashMap
      *
      * @param secretEngineVersions paths to use for accessing Vault secrets.
      *                             Key: secret path, value: Engine version to use.
@@ -144,7 +146,7 @@ public class VaultConfig implements Serializable {
      * @return This object, with secrets paths populated, ready for additional builder-pattern method calls or else finalization with the build() method
      */
     public VaultConfig secretsEnginePathMap(final Map<String, String> secretEngineVersions) {
-        this.secretsEnginePathMap = new ConcurrentHashMap<>(secretEngineVersions);
+        this.secretsEnginePathMap = new LinkedHashMap<>(secretEngineVersions);
         return this;
     }
 

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -627,6 +627,7 @@ public class Logical {
     /**
      * <p> Provides which secrets engine version to use for the desired path.
      * Checks to see if the relative path is in the secretsEnginePathMap, and returns the specified value if it is.
+     * Checks secretsEnginePathMap in order, so the first matching entry defined in the map takes precedence.
      * Otherwise return the globalEngineVersion. </p>
      *
      * @param secretPath The desired Vault path to access
@@ -634,10 +635,15 @@ public class Logical {
      */
     private Integer engineVersionForSecretPath(final String secretPath) {
         if (!this.config.getSecretsEnginePathMap().isEmpty()) {
-            Optional<String> matchedKeyPrefix = this.config.getSecretsEnginePathMap().keySet().stream()
-                    .filter(key -> secretPath.startsWith(key))
-                    .findFirst();
-            return matchedKeyPrefix.isPresent() ?
+            Optional<String> matchedKeyPrefix = null;
+            for (Map.Entry<String,String> secretPathMapping : this.config.getSecretsEnginePathMap().entrySet())
+            {
+                if(secretPath.startsWith(secretPathMapping.getKey())){
+                    matchedKeyPrefix = Optional.of(secretPathMapping.getKey());
+                    break;
+                }
+            }
+                return matchedKeyPrefix != null ?
                     Integer.valueOf(this.config.getSecretsEnginePathMap().get(matchedKeyPrefix.get()))
                     : this.config.getGlobalEngineVersion();
         }

--- a/src/main/java/com/bettercloud/vault/api/Logical.java
+++ b/src/main/java/com/bettercloud/vault/api/Logical.java
@@ -635,7 +635,7 @@ public class Logical {
      */
     private Integer engineVersionForSecretPath(final String secretPath) {
         if (!this.config.getSecretsEnginePathMap().isEmpty()) {
-            Optional<String> matchedKeyPrefix = null;
+            Optional<String> matchedKeyPrefix = Optional.empty();
             for (Map.Entry<String,String> secretPathMapping : this.config.getSecretsEnginePathMap().entrySet())
             {
                 if(secretPath.startsWith(secretPathMapping.getKey())){
@@ -643,7 +643,7 @@ public class Logical {
                     break;
                 }
             }
-                return matchedKeyPrefix != null ?
+                return matchedKeyPrefix.isPresent() ?
                     Integer.valueOf(this.config.getSecretsEnginePathMap().get(matchedKeyPrefix.get()))
                     : this.config.getGlobalEngineVersion();
         }

--- a/src/test/java/com/bettercloud/vault/VaultTests.java
+++ b/src/test/java/com/bettercloud/vault/VaultTests.java
@@ -4,6 +4,7 @@ import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.vault.VaultTestUtils;
 import com.bettercloud.vault.vault.mock.MockVault;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;
@@ -83,13 +84,29 @@ public class VaultTests {
 
     @Test
     public void kvEngineMapIsHonored() throws VaultException {
-        HashMap<String, String> testMap = new HashMap<>();
+        LinkedHashMap<String, String> testMap = new LinkedHashMap<>();
+        testMap.put("kv-v1/secret", "2");
         testMap.put("kv-v1", "1");
         VaultConfig vaultConfig = new VaultConfig().secretsEnginePathMap(testMap);
         Assert.assertNotNull(vaultConfig);
         Vault vault = new Vault(vaultConfig, true, 2);
         Assert.assertNotNull(vault);
         Assert.assertEquals(String.valueOf(1), vault.logical().getEngineVersionForSecretPath("kv-v1").toString());
+        Assert.assertEquals(String.valueOf(2), vault.logical().getEngineVersionForSecretPath("kv-v1/secret").toString());
+        Assert.assertEquals(String.valueOf(2), vault.logical().getEngineVersionForSecretPath("notInMap").toString());
+    }
+
+    @Test
+    public void kvEngineMapOrderIsHonored() throws VaultException {
+        LinkedHashMap<String, String> testMap = new LinkedHashMap<>();
+        testMap.put("kv-v1", "1");
+        testMap.put("kv-v1/secret", "2");
+        VaultConfig vaultConfig = new VaultConfig().secretsEnginePathMap(testMap);
+        Assert.assertNotNull(vaultConfig);
+        Vault vault = new Vault(vaultConfig, true, 2);
+        Assert.assertNotNull(vault);
+        Assert.assertEquals(String.valueOf(1), vault.logical().getEngineVersionForSecretPath("kv-v1").toString());
+        Assert.assertEquals(String.valueOf(1), vault.logical().getEngineVersionForSecretPath("kv-v1/secret").toString());
         Assert.assertEquals(String.valueOf(2), vault.logical().getEngineVersionForSecretPath("notInMap").toString());
     }
 


### PR DESCRIPTION
The secretsEnginePathMap was not honoring the order of lists due to the VaultConfig taking in whatever type of map was passed in and setting it to a ConcurrentHashMap. In order for the map to be ordered, set it to a LinkedHashMap instead and for loop through the map instead of streaming to maintain the order. Also add tests to check that flipping the order of the map prior to setting it in the Vault config is honored. 